### PR TITLE
Configure Drupal for persistent EFS file storage

### DIFF
--- a/.ebextensions/efs-mount.config
+++ b/.ebextensions/efs-mount.config
@@ -21,9 +21,11 @@
 container_commands:
   1chown:
     command: "chown webapp:webapp /drupalfiles"
-  2link:
+  2perms:
+    command: "sudo -u webapp chmod 777 /drupalfiles"
+  3link:
     command: "sudo -u webapp ln -s /drupalfiles web/sites/default/files"
-  
+
 packages:
   yum:
     nfs-utils: []

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -51,13 +51,14 @@ class ScriptHandler {
       $event->getIO()->write("Create a sites/default/settings.php file with chmod 0666");
     }
 
-    // Create the files directory with chmod 0777
-    if (!$fs->exists($drupalRoot . '/sites/default/files')) {
-      $oldmask = umask(0);
-      $fs->mkdir($drupalRoot . '/sites/default/files', 0777);
-      umask($oldmask);
-      $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
-    }
+    // Create the files directory with chmod 0777 ...
+    // ...but we don't create the files directory, because EFS will do that.
+    // if (!$fs->exists($drupalRoot . '/sites/default/files')) {
+    //   $oldmask = umask(0);
+    //   $fs->mkdir($drupalRoot . '/sites/default/files', 0777);
+    //   umask($oldmask);
+    //   $event->getIO()->write("Create a sites/default/files directory with chmod 0777");
+    // }
   }
 
   /**


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This changes how Drupal is deployed to accommodate the use of EFS for a persistent file store.

#### Helpful background context (if appropriate)
Normally, Drupal expects there to be a directory at `sites/default/files/` that is where it stores user-uploaded files. This is also where it stores aggregated JS and CSS files for performance optimization. Under our approach of using Composer to build and deploy Drupal from a source repo, this directory is normally created by Composer.

However, this doesn't allow for the file to persist between deploys.

#### How can a reviewer manually see the effects of these changes?
Upload an image to the running application, and then deploy the application again (thus far we've done this by scaling the application down to 0 and back). The image should still be available after the re-scaling.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DU-29

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
